### PR TITLE
Enhance item analytics with recent sales and underperforming item summary

### DIFF
--- a/src/main/java/com/ai/agent/ai_agent/config/DataSeeder.java
+++ b/src/main/java/com/ai/agent/ai_agent/config/DataSeeder.java
@@ -35,7 +35,7 @@ public class DataSeeder {
 
             for (int i = 1; i <= TOTAL_ITEMS; i++) {
                 double msrp = faker.number().randomDouble(2, 30, 500);
-                double storePrice = msrp - faker.number().randomDouble(2, 1, 50);
+                double storePrice = Math.max(1.0, msrp - faker.number().randomDouble(2, 1, 50));
                 double ecomPrice = Math.max(1.0, storePrice - faker.number().randomDouble(2, 0, 15));
                 double discount = Math.round(((msrp - storePrice) / msrp) * 10000.0) / 100.0;
 
@@ -47,6 +47,9 @@ public class DataSeeder {
                 ZonedDateTime now = ZonedDateTime.now();
                 ZonedDateTime promoStart = now.minusDays(faker.number().numberBetween(0, 5));
                 ZonedDateTime promoEnd = promoStart.plusDays(faker.number().numberBetween(1, 10));
+
+                int unitsSold = faker.number().numberBetween(0, 5000);
+                int recentSales = faker.number().numberBetween(0, Math.min(unitsSold, 300));
 
                 batch.add(ItemEntity.builder()
                         .itemId("ITEM" + String.format("%05d", i))
@@ -71,7 +74,8 @@ public class DataSeeder {
                         .lastPurchasedAt(now.minusDays(faker.number().numberBetween(1, 10)))
                         .averageRating(Math.round((faker.number().randomDouble(1, 2, 5)) * 10.0) / 10.0)
                         .numberOfReviews(faker.number().numberBetween(0, 1000))
-                        .unitsSold(faker.number().numberBetween(0, 5000))
+                        .unitsSold(unitsSold)
+                        .recentSalesCount(recentSales)
                         .build());
 
                 if (batch.size() == BATCH_SIZE) {

--- a/src/main/java/com/ai/agent/ai_agent/entity/ItemEntity.java
+++ b/src/main/java/com/ai/agent/ai_agent/entity/ItemEntity.java
@@ -72,4 +72,7 @@ public class ItemEntity {
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int unitsSold;
+
+    @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
+    private int recentSalesCount;
 }

--- a/src/main/java/com/ai/agent/ai_agent/mcp/tools/utils/ItemSummaryHelper.java
+++ b/src/main/java/com/ai/agent/ai_agent/mcp/tools/utils/ItemSummaryHelper.java
@@ -74,4 +74,24 @@ public class ItemSummaryHelper {
 
         return result.toString();
     }
+
+    public static String summarizeUnderperformingItems(List<ItemEntity> items) {
+        if (items == null || items.isEmpty()) {
+            return "No underperforming items found.";
+        }
+
+        StringBuilder sb = new StringBuilder("📉 Underperforming Items:\n");
+        int index = 1;
+        for (ItemEntity item : items) {
+            sb.append(String.format(
+                    "%d. %s (Units Sold: %d, Avg Rating: %.2f, Price: $%.2f)\n",
+                    index++,
+                    item.getItemName(),
+                    item.getUnitsSold(),
+                    item.getAverageRating(),
+                    item.getStorePrice()
+            ));
+        }
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
Added recentSalesCount to ItemEntity and updated DataSeeder to generate this field. Refactored InventoryTools to provide a new getUnderperformingItems tool that returns the bottom N items by sales and reviews, and improved demandForecast to use recent sales data. Introduced ItemSummaryHelper.summarizeUnderperformingItems for formatted output of underperforming items.